### PR TITLE
Flake util multi ${system} suppport

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
   };
 
   outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem ++ [ "powerpc64le-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
 
         pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
Took a stab at using flake-utils to support multiple system architectures as mentioned in #22 

If the user is importing directly into `home-manager.sharedModules` then they will need to make a change to `inputs.arkenfox.hmModules.${system}.default`

Wanted to know what your thoughts were to see if it would be possible to build off of this to make the change not so breaking.