### PR TITLE
Fix: Allow null firefox package

### DIFF
--- a/hm.nix
+++ b/hm.nix
@@ -6,7 +6,9 @@ versions: extracted: {
   inherit (lib) types;
 
   cfg = config.programs.firefox;
-  version = "${config.programs.firefox.package.version}";
+  version = if (config.programs.firefox.package != null)
+    then "${config.programs.firefox.package.version}"
+    else "unknown";
   ext = extracted."${cfg.arkenfox.version}";
 in {
   options.programs.firefox = {


### PR DESCRIPTION
`programs.firefox.package` is allowed to be null package in Home Manager (https://github.com/nix-community/home-manager/blob/master/modules/programs/firefox.nix#L240)

This PR fixed evaluation exception when comparing firefox and arkenfox versions.